### PR TITLE
feat(portfolio): 세부 페이지 레이아웃 재설계 & 뒤로가기 내비게이션 UX 개선

### DIFF
--- a/docs/components/PortfolioV3/PortfolioCard/PortfolioCardDialog.vue
+++ b/docs/components/PortfolioV3/PortfolioCard/PortfolioCardDialog.vue
@@ -1,78 +1,86 @@
 <template>
-  <dialog class="detail-view">
+  <dialog ref="dialogEl" class="detail-view" @close="onDialogClose">
+    <!-- Sticky Navigation Bar -->
     <nav class="detail-nav">
       <div class="nav-content">
-        <button @click="onClickBack" class="btn-back">
-          <span class="icon">←</span> 나가기
+        <button @click="closeDialog" class="btn-back">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+          <span>Portfolio</span>
         </button>
-        <div class="nav-meta">
-          <span>{{ category?.join(", ") }}</span>
-          <span class="dot"></span>
-          <span>{{ date }}</span>
-        </div>
+        <span class="nav-title">{{ title }}</span>
       </div>
     </nav>
 
+    <!-- Main Content -->
     <main class="detail-main">
+      <!-- Article Header -->
       <header class="detail-header">
-        <!-- <div class="detail-categories">
-          <span v-for="cat in category" :key="cat" class="detail-category">{{
+        <div class="header-meta">
+          <span v-for="cat in category" :key="cat" class="meta-tag">{{
             cat
           }}</span>
-        </div> -->
+        </div>
         <h1 class="detail-title">{{ title }}</h1>
-
-        <div class="detail-meta-grid">
-          <div class="meta-column">
-            <span class="meta-label">Skill</span>
-            <div class="meta-skills">
-              <div v-for="s in skill" :key="s.name" class="meta-skill">
+        <p class="detail-lead">{{ description }}</p>
+        <div class="header-info">
+          <div class="info-item" v-if="date">
+            <span class="info-label">Period</span>
+            <span class="info-value">{{ date }}</span>
+          </div>
+          <div class="info-item" v-if="skill && skill.length">
+            <span class="info-label">Stack</span>
+            <div class="info-skills">
+              <span v-for="s in skill" :key="s.name" class="skill-chip">
                 <img
                   v-if="s.logo"
                   :src="s.logo"
                   :alt="s.name"
-                  class="meta-skill-logo"
-                  :title="s.name"
+                  class="skill-icon"
                 />
-                <span class="meta-value">{{ s.name }}</span>
-              </div>
+                {{ s.name }}
+              </span>
             </div>
-          </div>
-          <div class="meta-column">
-            <span class="meta-label">Date</span>
-            <span class="meta-value">{{ date }}</span>
           </div>
         </div>
       </header>
 
-      <div class="main-visual">
-        <img :src="imageUrl" :alt="title" />
-      </div>
+      <!-- Divider -->
+      <hr class="section-divider" />
 
-      <div class="content-layout">
-        <article class="content-body">
-          <p class="lead-text">{{ description }}</p>
-          <slot></slot>
-        </article>
-
-        <!-- <aside class="content-sidebar">
-          <div class="sidebar-box">
-            <h4 class="sidebar-title">Project Info</h4>
-            <div class="info-row">
-              <span class="info-label">Client</span>
-              <span>Art Gallery Seoul</span>
-            </div>
-            <div class="info-row">
-              <span class="info-label">Role</span>
-              <span>Lead Curator</span>
-            </div>
-          </div>
-        </aside> -->
-      </div>
+      <!-- Article Body -->
+      <article class="detail-body">
+        <slot></slot>
+      </article>
     </main>
 
+    <!-- Footer -->
     <footer class="detail-footer">
-      <button @click="onClickBack" class="btn-footer-back">
+      <button @click="closeDialog" class="btn-footer-back">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m15 18-6-6 6-6" />
+        </svg>
         Back to Portfolio
       </button>
     </footer>
@@ -80,6 +88,7 @@
 </template>
 
 <script setup lang="ts">
+import { ref, onMounted, onBeforeUnmount } from "vue";
 import type { PropType } from "vue";
 
 defineProps({
@@ -103,258 +112,485 @@ defineProps({
   },
 });
 
-const emit = defineEmits(["back"]);
+const dialogEl = ref<HTMLDialogElement | null>(null);
+// popstate에 의해 닫히는 경우를 추적
+let closedByPopstate = false;
+// dialog가 열려 있는 동안 히스토리 상태를 추적
+let hasHistoryEntry = false;
 
-const handleBack = () => {
-  emit("back");
+/**
+ * History API 연동:
+ * dialog를 열 때 pushState로 히스토리 엔트리를 추가하고,
+ * 브라우저 뒤로가기(popstate)를 감지하면 dialog를 닫는다.
+ * 이렇게 하면 뒤로가기 시 포트폴리오 목록이 아닌 이전 페이지로 가는 문제를 방지하고,
+ * 동시에 목록 페이지의 스크롤 위치도 보존된다.
+ */
+const onPopState = () => {
+  if (dialogEl.value?.open) {
+    closedByPopstate = true;
+    hasHistoryEntry = false;
+    dialogEl.value.close();
+  }
 };
 
-const onClickBack = () => {
-  const modal: HTMLDialogElement | null =
-    document.querySelector(".detail-view");
+onMounted(() => {
+  window.addEventListener("popstate", onPopState);
+});
 
-  modal?.close();
+onBeforeUnmount(() => {
+  window.removeEventListener("popstate", onPopState);
+});
+
+const openDialog = () => {
+  if (!dialogEl.value) return;
+  // 히스토리에 상태를 푸시하여 뒤로가기로 dialog를 닫을 수 있게 함
+  history.pushState({ portfolioDetail: true }, "");
+  hasHistoryEntry = true;
+  closedByPopstate = false;
+  dialogEl.value.showModal();
+  dialogEl.value.scrollTop = 0;
 };
+
+const closeDialog = () => {
+  if (!dialogEl.value?.open) return;
+  dialogEl.value.close();
+};
+
+const onDialogClose = () => {
+  // popstate에 의해 닫힌 경우: 이미 히스토리가 뒤로 간 상태이므로 아무 작업 불필요
+  if (closedByPopstate) {
+    closedByPopstate = false;
+    return;
+  }
+  // 버튼 클릭이나 ESC에 의해 닫힌 경우: pushState로 추가한 엔트리를 제거
+  if (hasHistoryEntry) {
+    hasHistoryEntry = false;
+    history.back();
+  }
+};
+
+defineExpose({
+  openDialog,
+  closeDialog,
+  $el: dialogEl,
+});
 </script>
 
 <style scoped>
-/* Detail View Styles */
+/* ==========================================================================
+   Dialog Base
+   ========================================================================== */
 .detail-view {
-  &[open] {
-    background: white;
-    color: #333;
-    min-height: 100vh;
-    width: 100%;
-    .detail-nav {
-      position: sticky;
-      top: 0;
-      background: rgba(255, 255, 255, 0.9);
-      backdrop-filter: blur(10px);
-      border-bottom: 1px solid #f0f0f0;
-      z-index: 100;
-    }
-    border: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  max-width: 100%;
+  max-height: 100%;
+  width: 100%;
+  height: 100%;
+  background: #ffffff;
+  color: #1a1a1a;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+}
 
-    .nav-content {
-      max-width: 1200px;
-      margin: 0 auto;
-      height: 80px;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 0 24px;
-    }
+.detail-view::backdrop {
+  background: rgba(0, 0, 0, 0.3);
+}
 
-    .btn-back {
-      background: none;
-      border: none;
-      cursor: pointer;
-      font-size: 14px;
-      font-weight: 600;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
+/* Smooth scrollbar hide */
+.detail-view::-webkit-scrollbar {
+  width: 0;
+}
+.detail-view {
+  scrollbar-width: none;
+}
 
-    .nav-meta {
-      font-size: 11px;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: #888888;
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
+/* ==========================================================================
+   Navigation
+   ========================================================================== */
+.detail-nav {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid #f0f0f0;
+}
 
-    .dot {
-      width: 4px;
-      height: 4px;
-      background: #ccc;
-      border-radius: 50%;
-    }
+.nav-content {
+  max-width: 720px;
+  margin: 0 auto;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  gap: 1rem;
+}
 
-    .detail-main {
-      max-width: 1000px;
-      margin: 0 auto;
-      padding: 60px 24px;
-    }
+.btn-back {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #1a1a1a;
+  padding: 6px 10px 6px 6px;
+  border-radius: 6px;
+  transition: background-color 0.15s ease;
+  flex-shrink: 0;
+}
+.btn-back:hover {
+  background-color: #f5f5f5;
+}
 
-    .detail-categories {
-      display: flex;
-      gap: 8px;
-      flex-wrap: wrap;
-      margin-bottom: 24px;
-    }
+.nav-title {
+  font-size: 0.75rem;
+  color: #999;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
 
-    .detail-category {
-      display: inline-block;
-      border: 1px solid black;
-      padding: 4px 12px;
-      font-size: 10px;
-      font-weight: 900;
-    }
+/* ==========================================================================
+   Main Content Area — narrow, text-optimized
+   ========================================================================== */
+.detail-main {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+}
 
-    .meta-skills {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-    }
-
-    .meta-skill {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-
-    .meta-skill-logo {
-      width: 20px;
-      height: 20px;
-      object-fit: contain;
-      opacity: 0.8;
-      transition: opacity 0.2s ease;
-    }
-
-    .meta-skill-logo:hover {
-      opacity: 1;
-    }
-
-    .detail-title {
-      font-size: clamp(40px, 8vw, 72px);
-      font-weight: 800;
-      line-height: 1.1;
-      letter-spacing: -0.04em;
-      margin-bottom: 40px;
-    }
-
-    .detail-meta-grid {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 40px;
-      padding-top: 32px;
-      border-top: 1px solid #f0f0f0;
-      margin-bottom: 60px;
-    }
-
-    .meta-column {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-
-    .meta-label {
-      font-size: 10px;
-      text-transform: uppercase;
-      color: #888888;
-      letter-spacing: 0.1em;
-    }
-
-    .meta-value {
-      font-size: 14px;
-      font-weight: 600;
-    }
-
-    .main-visual {
-      margin-bottom: 60px;
-      border: 1px solid #f0f0f0;
-    }
-
-    .main-visual img {
-      width: 60%;
-      margin: 0 auto;
-      display: block;
-    }
-
-    .content-layout {
-      display: grid;
-      grid-template-columns: 1fr;
-      gap: 60px;
-    }
-
-    /* @media (min-width: 768px) {
-      .content-layout {
-        grid-template-columns: 2fr 1fr;
-      }
-    } */
-
-    .content-body {
-      font-size: 18px;
-      line-height: 1.7;
-      color: #333;
-    }
-
-    .lead-text {
-      font-weight: 600;
-      color: black;
-      margin-bottom: 32px;
-    }
-
-    .content-placeholder {
-      height: 300px;
-      background: #f9f9f9;
-      border: 1px dashed #ddd;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin: 40px 0;
-      font-size: 12px;
-      color: #999;
-    }
-
-    .sidebar-box {
-      border: 1px solid #f0f0f0;
-      padding: 32px;
-    }
-
-    .sidebar-title {
-      font-size: 11px;
-      text-transform: uppercase;
-      font-weight: 900;
-      border-bottom: 1px solid black;
-      display: inline-block;
-      margin-bottom: 24px;
-    }
-
-    .info-row {
-      display: flex;
-      justify-content: space-between;
-      font-size: 13px;
-      padding-bottom: 12px;
-      margin-bottom: 12px;
-      border-bottom: 1px solid #f5f5f5;
-    }
-
-    .info-label {
-      color: #888888;
-    }
-
-    .detail-footer {
-      border-top: 1px solid #f0f0f0;
-      padding: 60px 24px;
-      text-align: center;
-    }
-
-    .btn-footer-back {
-      background: none;
-      border: none;
-      text-transform: uppercase;
-      font-size: 11px;
-      font-weight: 900;
-      letter-spacing: 0.2em;
-      cursor: pointer;
-    }
-
-    .btn-footer-back:hover {
-      text-decoration: underline;
-    }
-
-    .btn-icon {
-      padding: 8px 16px;
-      border: 1px solid #eee;
-      background: white;
-      border-radius: 4px;
-      font-size: 12px;
-      cursor: pointer;
-    }
+@media (min-width: 768px) {
+  .detail-main {
+    padding: 4rem 2rem 5rem;
   }
+}
+
+/* ==========================================================================
+   Header
+   ========================================================================== */
+.detail-header {
+  margin-bottom: 0;
+}
+
+.header-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 1.25rem;
+}
+
+.meta-tag {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 4px 10px;
+  border: 1px solid #e0e0e0;
+  border-radius: 3px;
+  color: #666;
+}
+
+.detail-title {
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.2;
+  letter-spacing: -0.03em;
+  color: #111;
+  margin: 0 0 1.25rem 0;
+}
+
+@media (min-width: 768px) {
+  .detail-title {
+    font-size: 2.5rem;
+  }
+}
+
+.detail-lead {
+  font-size: 1rem;
+  line-height: 1.75;
+  color: #444;
+  margin: 0 0 2rem 0;
+  word-break: keep-all;
+}
+
+@media (min-width: 768px) {
+  .detail-lead {
+    font-size: 1.0625rem;
+    line-height: 1.8;
+  }
+}
+
+/* Header Info Grid */
+.header-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
+.info-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.info-label {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #999;
+}
+
+.info-value {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #333;
+}
+
+.info-skills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.skill-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: #444;
+}
+
+.skill-icon {
+  width: 16px;
+  height: 16px;
+  object-fit: contain;
+}
+
+/* ==========================================================================
+   Divider
+   ========================================================================== */
+.section-divider {
+  border: none;
+  border-top: 1px solid #e8e8e8;
+  margin: 2.5rem 0;
+}
+
+/* ==========================================================================
+   Article Body — override children for clean typography
+   ========================================================================== */
+.detail-body {
+  font-size: 1rem;
+  line-height: 1.8;
+  color: #333;
+  word-break: keep-all;
+}
+
+/* Content card children styles */
+.detail-body :deep(.portfolio-wrapper) {
+  min-height: auto;
+  background: transparent;
+  color: inherit;
+}
+
+.detail-body :deep(.global-header) {
+  display: none;
+}
+
+.detail-body :deep(.global-footer) {
+  display: none;
+}
+
+.detail-body :deep(.portfolio-container) {
+  max-width: 100%;
+  padding: 0;
+}
+
+.detail-body :deep(.section-block) {
+  padding-bottom: 2.5rem;
+}
+
+.detail-body :deep(.section-title) {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 1.5rem;
+  color: #111;
+  padding-top: 0;
+}
+
+@media (min-width: 768px) {
+  .detail-body :deep(.section-title) {
+    font-size: 1.75rem;
+  }
+}
+
+.detail-body :deep(.sub-title) {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #222;
+  margin-bottom: 0.75rem;
+}
+
+.detail-body :deep(.text-lead) {
+  font-size: 1rem;
+  line-height: 1.75;
+  font-weight: 500;
+  color: #333;
+}
+
+.detail-body :deep(.text-body) {
+  font-size: 0.9375rem;
+  line-height: 1.8;
+  color: #555;
+}
+
+@media (min-width: 768px) {
+  .detail-body :deep(.text-body) {
+    font-size: 1rem;
+  }
+}
+
+.detail-body :deep(.highlight-text) {
+  font-style: italic;
+  color: #333;
+  border-left: 3px solid #d32f2f;
+  padding-left: 1rem;
+  margin: 1.25rem 0;
+  font-size: 0.9375rem;
+  line-height: 1.75;
+}
+
+.detail-body :deep(.clean-card) {
+  border: 1px solid #eee;
+  border-radius: 6px;
+  padding: 1.25rem;
+  background: #fafafa;
+  transition: none;
+}
+.detail-body :deep(.clean-card:hover) {
+  transform: none;
+  box-shadow: none;
+}
+
+.detail-body :deep(.card-title) {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #222;
+  margin-bottom: 0.5rem;
+}
+
+.detail-body :deep(.accent-line) {
+  height: 2px;
+  background-color: #d32f2f;
+  margin-bottom: 1.5rem;
+  opacity: 0.6;
+}
+
+.detail-body :deep(.image-placeholder) {
+  padding: 2rem 1rem;
+  border-radius: 6px;
+  margin: 1.5rem 0;
+}
+
+.detail-body :deep(.image-placeholder img) {
+  max-width: 100%;
+  height: auto;
+}
+
+.detail-body :deep(.border-top-thin) {
+  border-top: 1px solid #eee;
+}
+
+.detail-body :deep(.pt-xlarge) {
+  padding-top: 2.5rem;
+}
+
+.detail-body :deep(.space-y-xlarge > * + *) {
+  margin-top: 2.5rem;
+}
+
+.detail-body :deep(.impl-item) {
+  padding: 1rem 0;
+}
+
+.detail-body :deep(.inline-tag) {
+  font-size: 0.6875rem !important;
+  padding: 2px 8px !important;
+  background-color: #f0f0f0 !important;
+  border: 1px solid #e0e0e0 !important;
+  border-radius: 3px !important;
+  color: #555 !important;
+}
+
+.detail-body :deep(.disclaimer-banner) {
+  margin: 0 0 2rem 0;
+  padding: 0.75rem 1rem;
+  background: #fafafa;
+  border: 1px solid #f0f0f0;
+  border-radius: 6px;
+  font-size: 0.8125rem;
+  color: #777;
+  font-style: italic;
+}
+
+/* Tech stack compact */
+.detail-body :deep(.tech-stack-grid) {
+  gap: 1rem;
+}
+.detail-body :deep(.tech-stack-card) {
+  padding: 0;
+}
+.detail-body :deep(.tech-stack-heading) {
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+.detail-body :deep(.tech-stack-list li) {
+  font-size: 0.8125rem;
+}
+
+.detail-body :deep(.cards-grid) {
+  gap: 1rem;
+}
+
+/* ==========================================================================
+   Footer
+   ========================================================================== */
+.detail-footer {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+  border-top: 1px solid #f0f0f0;
+}
+
+.btn-footer-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 10px 16px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: #555;
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  transition: all 0.15s ease;
+}
+.btn-footer-back:hover {
+  border-color: #999;
+  color: #222;
+  background-color: #fafafa;
 }
 </style>

--- a/docs/components/PortfolioV3/PortfolioMain.vue
+++ b/docs/components/PortfolioV3/PortfolioMain.vue
@@ -153,9 +153,7 @@
           :category="selectedCardData?.category"
           :title="selectedCardData?.title"
           :description="selectedCardData?.description"
-          :imageUrl="selectedCardData?.imageUrl"
           :skill="selectedCardData?.skill"
-          :duration="selectedCardData?.duration"
         >
           <KeepAlive>
             <component :is="selectedCardData?.contents" />
@@ -441,9 +439,7 @@ const scrollPage = (direction) => {
 
 const onClickCard = (id) => {
   selectedCardData.value = portfolioData.find((data) => data.id === id);
-
-  modal.value.$el.showModal();
-  modal.value.$el.scrollTop = 0;
+  modal.value?.openDialog();
 };
 </script>
 


### PR DESCRIPTION
## 변경 사항

### 1. 포트폴리오 세부 페이지 레이아웃 재설계 (미니멀리즘 / 텍스트 중심)

- **콘텐츠 폭 720px**로 제한하여 텍스트 가독성 극대화 (최적의 읽기 폭)
- 기존의 대형 히어로 이미지 제거 → 텍스트 콘텐츠에 집중
- 아티클 스타일 헤더: 카테고리 태그 → 타이틀 → 리드 텍스트 → 메타 정보 순의 명확한 시각적 위계
- Sticky 네비게이션 바: 블러 배경 + 뒤로가기 버튼 + 현재 글 제목
- `:deep()` CSS로 하위 콘텐츠 카드 컴포넌트 스타일 정규화:
  - 중복 헤더/푸터 숨김
  - 타이포그래피 스케일 축소 (세부 페이지에 맞게)
  - 간격/여백 최적화
- `line-height: 1.8`, `word-break: keep-all`로 한국어 텍스트 가독성 최적화

### 2. Dialog 뒤로가기 내비게이션 UX 개선 (History API)

**문제:**
- Dialog 방식: 뒤로가기 누르면 포트폴리오 목록이 아닌 **완전히 이전 페이지**로 이동
- Route 방식: 뒤로가기 시 **스크롤 위치 초기화**

**해결:**
- Dialog를 열 때 `history.pushState()`로 히스토리 엔트리 추가
- `popstate` 이벤트 감지하여 뒤로가기 시 dialog 닫기
- 닫기 버튼/ESC로 닫을 때는 `history.back()`으로 히스토리 정리
- 닫기 원인(popstate vs 수동) 추적으로 이중 히스토리 조작 방지
- 포트폴리오 목록의 **스크롤 위치 완벽 보존**

## 수정된 파일
- `docs/components/PortfolioV3/PortfolioCard/PortfolioCardDialog.vue` — 전면 재작성
- `docs/components/PortfolioV3/PortfolioMain.vue` — 새 dialog API 사용